### PR TITLE
Fix generate_warning_points.py

### DIFF
--- a/spt_compute/imports/generate_warning_points.py
+++ b/spt_compute/imports/generate_warning_points.py
@@ -192,7 +192,7 @@ def generate_ecmwf_warning_points(ecmwf_prediction_folder, return_period_file,
         std_ar = std_ds.isel(rivid=rivid_index)
         std_upper_ar = (mean_ar + std_ar)
         max_ar = max_ds.isel(rivid=rivid_index)
-        std_upper_ar[std_upper_ar > max_ar] = max_ar
+        std_upper_ar = np.minimum(std_upper_ar, max_ar)
 
         combinded_stats = pd.DataFrame({
             'mean': mean_ar.to_dataframe().Qout,


### PR DESCRIPTION
Updated std_upper_ar variable since Numpy behavior changed quite some time ago
std_upper_ar[std_upper_ar > max_ar] no longer works; changed to np.minimum(std_upper_ar, max_ar)